### PR TITLE
Feature/popular categories

### DIFF
--- a/components/molecules/PopularCategoryCard.js
+++ b/components/molecules/PopularCategoryCard.js
@@ -1,9 +1,7 @@
 import PropTypes from "prop-types";
-import { useTranslation } from "next-i18next";
 import Image from "next/image";
 
 export function PopularCategoryCard(props) {
-  const { t } = useTranslation("common");
   return (
     <div className="flex flex-col md:w-64 lg:w-1/3 ">
       <div className="px-3 py-2">

--- a/components/molecules/PopularCategoryCard.js
+++ b/components/molecules/PopularCategoryCard.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import { useTranslation } from "next-i18next";
+import Image from "next/image";
 
 export function PopularCategoryCard(props) {
   const { t } = useTranslation("common");
@@ -7,11 +8,19 @@ export function PopularCategoryCard(props) {
     <div className="flex flex-col md:w-64 lg:w-1/3 ">
       <div className="px-3 py-2">
         <div className="rounded-lg border p-5">
-          <div>
-            <img src={props.imgSource} alt={props.altText} />
+          <div
+            className={"py-2"}
+            style={{ position: "relative", width: "100%", height: "5rem" }}
+          >
+            <Image
+              layout="fill"
+              objectFit="contain"
+              src={props.imgSource}
+              alt={props.imgAltText}
+            />
           </div>
           <small className="text-gray-500 uppercase">{props.type}</small>
-          <div className="flex w-full">
+          <div className="flex w-full py-2">
             <div className="flex flex-col justify-start">
               <a href="#catalog">
                 <h3 className="text-lg">{props.title}</h3>
@@ -44,7 +53,7 @@ PopularCategoryCard.propTypes = {
   /**
    * category image alt text
    */
-  altText: PropTypes.string.isRequired,
+  imgAltText: PropTypes.string.isRequired,
 
   /**
    * category description

--- a/components/molecules/PopularCategoryCard.js
+++ b/components/molecules/PopularCategoryCard.js
@@ -1,0 +1,58 @@
+import PropTypes from "prop-types";
+import { useTranslation } from "next-i18next";
+
+export function PopularCategoryCard(props) {
+  const { t } = useTranslation("common");
+  return (
+    <div className="flex flex-col md:w-64 lg:w-1/3 ">
+      <div className="px-3 py-2">
+        <div className="rounded-lg border p-5">
+          <div>
+            <img src={props.imgSource} alt={props.altText} />
+          </div>
+          <small className="text-gray-500 uppercase">{props.type}</small>
+          <div className="flex w-full">
+            <div className="flex flex-col justify-start">
+              <a href="#catalog">
+                <h3 className="text-lg">{props.title}</h3>
+              </a>
+            </div>
+          </div>
+          <p className="truncate-4-lines py-2">{props.description}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+PopularCategoryCard.propTypes = {
+  /**
+   * category id
+   */
+  id: PropTypes.string.isRequired,
+
+  /**
+   * category title
+   */
+  title: PropTypes.string.isRequired,
+
+  /**
+   * category image source
+   */
+  imgSource: PropTypes.string.isRequired,
+
+  /**
+   * category image alt text
+   */
+  altText: PropTypes.string.isRequired,
+
+  /**
+   * category description
+   */
+  description: PropTypes.string,
+
+  /**
+   * category type
+   */
+  type: PropTypes.string,
+};

--- a/components/molecules/PopularCategoryCard.stories.js
+++ b/components/molecules/PopularCategoryCard.stories.js
@@ -22,5 +22,5 @@ Primary.args = {
   description: "Category description",
   type: "Category type",
   imgSource: "/landscape.png",
-  altText: "Category image alt text",
+  imgAltText: "Category image alt text",
 };

--- a/components/molecules/PopularCategoryCard.stories.js
+++ b/components/molecules/PopularCategoryCard.stories.js
@@ -1,0 +1,26 @@
+import { PopularCategoryCard } from "./PopularCategoryCard";
+import logo from "../../public/wmms-blk.svg";
+
+export default {
+  title: "Components/Molecules/PopularCategoryCard",
+  component: PopularCategoryCard,
+  decorators: [
+    (Story) => (
+      <div className="flex w-full p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+const Template = (args) => <PopularCategoryCard {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  id: "category-id",
+  title: "Category Title",
+  description: "Category description",
+  type: "Category type",
+  imgSource: "/landscape.png",
+  altText: "Category image alt text",
+};

--- a/components/molecules/PopularCategoryCard.test.js
+++ b/components/molecules/PopularCategoryCard.test.js
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Primary } from "./PopularCategoryCard.stories";
+
+expect.extend(toHaveNoViolations);
+
+describe("PopularCategoryCard tests", () => {
+  it("renders a Popular Category Card in its primary state", () => {
+    render(<Primary {...Primary.args} />);
+    const title = screen.getByText("Category Title");
+    const description = screen.getByText("Category description");
+    const type = screen.getByText("Category type");
+
+    expect(title).toBeInTheDocument();
+    expect(description).toBeInTheDocument();
+    expect(type).toBeInTheDocument();
+  });
+
+  it("has no a11y violations", async () => {
+    const { container } = render(<Primary {...Primary.args} />);
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/categories.js
+++ b/lib/categories.js
@@ -1,0 +1,29 @@
+// todo: get data from the cms, determine popular categories some other way - maybe analytics?
+export function getPopularCategories(locale) {
+  return [
+    {
+      id: `cat-1`,
+      title: `[${locale}] Category 1`,
+      description: `[${locale}] Description for category 1`,
+      type: `[${locale}] OAS`,
+      imgSource: `/sig-blk-en.svg`,
+      imgAltText: `[${locale}] just an image of something`,
+    },
+    {
+      id: `cat-2`,
+      title: `[${locale}] Category 2`,
+      description: `[${locale}] Description for category 2`,
+      type: `[${locale}] EI`,
+      imgSource: `/vercel.svg`,
+      imgAltText: `[${locale}] just an image of something`,
+    },
+    {
+      id: `cat-3`,
+      title: `[${locale}] Category 3`,
+      description: `[${locale}] Description for category 3`,
+      type: `[${locale}] Programs`,
+      imgSource: `/wmms-blk.svg`,
+      imgAltText: `[${locale}] just an image of something`,
+    },
+  ];
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,24 +2,41 @@ import Head from "next/head";
 import { Layout } from "../components/organisms/Layout";
 import { BenefitGrid } from "../components/organisms/BenefitGrid";
 import { getBenefits } from "../lib/benefits";
+import { getPopularCategories } from "../lib/categories";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useRouter } from "next/router";
+import { PopularCategoryCard } from "../components/molecules/PopularCategoryCard";
 
 export async function getStaticProps(context) {
   const locale = context.locale || context.defaultLocale;
+  const popularCatagories = getPopularCategories(locale);
   return {
     props: {
       locale,
       ...(await serverSideTranslations(locale, ["common"])),
+      popularCatagories,
     },
   };
 }
 
-export default function Home({ locale }) {
+export default function Home({ locale, popularCatagories }) {
   const { t } = useTranslation("common");
   const { asPath } = useRouter();
   const benefits = getBenefits(t);
+  const categories = popularCatagories.map((cat) => {
+    return (
+      <PopularCategoryCard
+        key={cat.id}
+        id={cat.id}
+        title={cat.title}
+        description={cat.description}
+        type={cat.type}
+        imgSource={cat.imgSource}
+        imgAltText={cat.imgSource}
+      />
+    );
+  });
   return (
     <Layout locale={locale} langUrl={asPath}>
       <Head>
@@ -32,7 +49,11 @@ export default function Home({ locale }) {
 
       <section id="popular_catagories" className="">
         <h3 className="text-2xl text-bold py-3">{t("popularCatagories")}</h3>
-        <p>{t("underConstruction")}</p>
+        <div className="w-full flex flex-col items-center md:items-start">
+          <div className="w-full flex flex-wrap justify-between">
+            {categories}
+          </div>
+        </div>
       </section>
 
       <section id="catalog" className="">

--- a/pages/index.js
+++ b/pages/index.js
@@ -30,12 +30,12 @@ export default function Home({ locale }) {
         <h1 className="text-4xl text-bold">{t("findSupport")}</h1>
       </div>
 
-      <section className="">
+      <section id="popular_catagories" className="">
         <h3 className="text-2xl text-bold py-3">{t("popularCatagories")}</h3>
         <p>{t("underConstruction")}</p>
       </section>
 
-      <section className="">
+      <section id="catalog" className="">
         <h3 className="text-2xl text-bold py-3">{t("catalog")}</h3>
         <BenefitGrid benefits={benefits} />
       </section>

--- a/pages/index.js
+++ b/pages/index.js
@@ -33,7 +33,7 @@ export default function Home({ locale, popularCatagories }) {
         description={cat.description}
         type={cat.type}
         imgSource={cat.imgSource}
-        imgAltText={cat.imgSource}
+        imgAltText={cat.imgAltText}
       />
     );
   });


### PR DESCRIPTION
# Description

[BF-79 Create popular category card](https://bf-decd.atlassian.net/browse/BF-79?atlOrigin=eyJpIjoiZDM5OGNkZTc5ZTJhNDUzNDlmMTg3ZTVjMzZlYzQ3MzQiLCJwIjoiaiJ9)
[BF-81 Add popular category grid to home page](https://bf-decd.atlassian.net/browse/BF-81?atlOrigin=eyJpIjoiYmIxYjk3NzUxOTUwNGE0NzliNWU3Nzc5ZWE2NTA1OTMiLCJwIjoiaiJ9)

Created a popular category card component. I created it separately from the benefit card, but they do share a lot of similarities. I kind of wanted to keep (somewhat) complex logic out of the components, but it might make more sense to create a more generic card component that benefits and categories can use.

Added the cards to the home page, but didn't put them in a grid component - for similar reasons as above, a generic component might make sense, but I just wanted these things on the page for now.


## Meets Definition of Done
- [x] Checked against style guide as currently understood
- [ ] Acceptance criteria met
- [x] Unit tests up to date
- [ ] E2E tests up to date
- [ ] Security up to standards
- [x] I18n