### PR TITLE
Used class names instead of global selectors.

### DIFF
--- a/components/atoms/DrawerItem.js
+++ b/components/atoms/DrawerItem.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 export function DrawerItem(props) {
   return (
     <details className="pt-7 mt-7 border-t border-gray-300">
-      <summary className="w-full relative cursor-pointer list-none px-0 text-base font-semibold ">
+      <summary className="drawerSummary w-full relative cursor-pointer list-none px-0 text-base font-semibold ">
         {props.summary}
       </summary>
       {props.children}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,7 @@
 import { appWithTranslation } from "next-i18next";
 import "../styles/globals.css";
 import "../icomoon/style.css";
-import "../styles/situation.css";
+import "../styles/drawerItem.css";
 import "../styles/drawer.css";
 
 function MyApp({ Component, pageProps }) {

--- a/styles/drawerItem.css
+++ b/styles/drawerItem.css
@@ -1,6 +1,6 @@
 /* Details under the summary fade-in animation (when opening the summary) */
 /* Start */
-details[open] summary ~ * {
+details[open] .drawerSummary ~ * {
   animation: open 0.3s ease-in-out;
 }
   
@@ -12,14 +12,14 @@ details[open] summary ~ * {
     opacity: 1;
   }
 }
-details summary::-webkit-details-marker {
+details .drawerSummary::-webkit-details-marker {
   display: none;
 }
 /* End */
 
 /* Closed drawer item */
 /* Start */
-details summary:after {
+details .drawerSummary:after {
   content: "+";
   position: absolute;
   font-size: 1.75rem;
@@ -33,7 +33,7 @@ details summary:after {
 
 /* Opened drawer item */
 /* Start */
-details[open] summary:after {
+details[open] .drawerSummary:after {
   transform: rotate(45deg);
   font-size: 2rem;
   right: -4px


### PR DESCRIPTION
# Description

Changed the DrawerItem.js to use CSS classes from the drawerItem.css instead of using global selectors from the CSS files.

This way, when we add details and summary elements, it won't take the global selectors from the drawerItem.css.

**Example:**

details[open] **summary**:after {
  transform: rotate(45deg);
  font-size: 2rem;
  right: -4px
}

**is now:**

details[open] **.drawerSummary**:after {
  transform: rotate(45deg);
  font-size: 2rem;
  right: -4px
}

## Meets Definition of Done
- [x] Unit tests up to date
- [x] E2E tests up to date
- [x] I18n