### PR TITLE
Remove missed reference to collections

### DIFF
--- a/lib/benefits.js
+++ b/lib/benefits.js
@@ -59,8 +59,8 @@ function mapBenefit(benefit, lang) {
     provider: benefit[`Provider_${lang}`],
     type: benefit[`type`] ? benefit[`type`][`Type_${lang}`] : "",
     program: benefit[`program`] ? benefit[`program`][`Title_${lang}`] : "",
-    collections: benefit[`collections`].map((collection) => {
-      return collection[`Title_${lang}`];
+    bundles: benefit[`bundles`].map((bundle) => {
+      return bundle["id"];
     }),
   };
 }

--- a/lib/benefits.test.js
+++ b/lib/benefits.test.js
@@ -96,15 +96,7 @@ const mockBenefits = [
     EligibilityCriteria_FR:
       "(FR) - you are aged 60 to 64 (includes the month of your 65th birthday); (Age)\n- you are a Canadian citizen or a legal resident;\n- you reside in Canada and have resided in Canada for at least 10 years since the age of 18;\n- your spouse or common-law partner has died and you have not remarried or entered into a common-law relationship; and\n- your annual income is less than the maximum annual threshold.",
     BenefitKey: "alws",
-    collections: [
-      {
-        id: 1,
-        Title_EN: "Public Pension",
-        Title_FR: "(FR) Public Pension",
-        Description_EN: "Public Pension ",
-        Description_FR: "(FR) Public Pension",
-      },
-    ],
+    bundles: [{ id: 1 }, { id: 2 }],
   },
   {
     id: 4,
@@ -139,14 +131,6 @@ const mockBenefits = [
     EligibilityCriteria_FR:
       "(FR) - you are 65 or older\n- you live in Canada\n- you receive the Old Age Security (OAS) pension\n- your income is below $18,648 if you are single, widowed, or divorced\nyour income plus the income of your spouse/common-law partner is below:\n- $24,624 if your spouse/common-law partner receives the full OAS pension\n- $44,688 if your spouse/common-law partner does not receive an OAS pension\n- $44,688 if your spouse/common-law partner receives the Allowance\n",
     BenefitKey: "cpp-gis",
-    collections: [
-      {
-        id: 1,
-        Title_EN: "Public Pension",
-        Title_FR: "(FR) Public Pension",
-        Description_EN: "Public Pension ",
-        Description_FR: "(FR) Public Pension",
-      },
-    ],
+    bundles: [{ id: 2 }],
   },
 ];


### PR DESCRIPTION
# Description

This PR fixes a bug introduced in #81 where a reference to collections was not replaced, causing the benefits not to load.