### PR TITLE
Remove required image in PopularCategoryCard

### DIFF
--- a/components/molecules/PopularCategoryCard.js
+++ b/components/molecules/PopularCategoryCard.js
@@ -47,12 +47,12 @@ PopularCategoryCard.propTypes = {
   /**
    * category image source
    */
-  imgSource: PropTypes.string.isRequired,
+  imgSource: PropTypes.string,
 
   /**
    * category image alt text
    */
-  imgAltText: PropTypes.string.isRequired,
+  imgAltText: PropTypes.string,
 
   /**
    * category description


### PR DESCRIPTION
# Description

Remove requirement for images in popular category card component. I'm not sure why it was set as required, but it was causing client errors if no image was available, so removing the requirement lets the component skip rendering the image if it doesn't exist.